### PR TITLE
Fix Ontop empty file creation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 *.sparql text eol=lf
 *.ttl text eol=lf
 *.patch text eol=lf
+*.txt text eol=lf
 
 # Windows line endings
 *.bat text eol=crlf

--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.43.0
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.43.1-fix-ontop-empty-file-creation-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.44.1-fix-ontop-empty-file-creation-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.44.1
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.43.0</version>
+    <version>1.43.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.44.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
+    <version>1.44.1</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DatasetLoader.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/clients/core/datasets/DatasetLoader.java
@@ -279,7 +279,7 @@ public class DatasetLoader {
             ontopMappings.forEach(mapping -> ontopClient.updateOBDA(directory.resolve(mapping)));
 
             if (PostGISClient.DEFAULT_DATABASE_NAME.equals(dataset.getDatabase())) {
-                OntopClient defaultOntopClient = OntopClient.getInstance();
+                OntopClient defaultOntopClient = OntopClient.getInstance(EndpointNames.ONTOP);
                 ontopMappings.forEach(mapping -> defaultOntopClient.updateOBDA(directory.resolve(mapping)));
             }
 

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/clients/ontop/OntopClient.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/clients/ontop/OntopClient.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 
 import com.cmclinnovations.stack.clients.blazegraph.BlazegraphClient;
 import com.cmclinnovations.stack.clients.core.ClientWithEndpoint;
-import com.cmclinnovations.stack.clients.core.EndpointNames;
 import com.cmclinnovations.stack.clients.core.datasets.CopyDatasetQuery;
 import com.cmclinnovations.stack.clients.utils.SparqlRulesFile;
 import com.cmclinnovations.stack.clients.utils.TempFile;
@@ -30,10 +29,6 @@ public class OntopClient extends ClientWithEndpoint<OntopEndpointConfig> {
     public static final String ONTOP_SPARQL_RULES_FILE = "ONTOP_SPARQL_RULES_FILE";
 
     private static Map<String, OntopClient> instances = new HashMap<>();
-
-    public static OntopClient getInstance() {
-        return getInstance(EndpointNames.ONTOP);
-    }
 
     public static OntopClient getInstance(String containerName) {
         return instances.computeIfAbsent(containerName, OntopClient::new);

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/CityTilerService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/CityTilerService.java
@@ -44,7 +44,7 @@ public final class CityTilerService extends ContainerService {
 
             patch = patch.replaceAll("\\r\\n?", "\n");
 
-            String execId = dockerClient.createComplexCommand(dockerClient.getContainerId(TYPE), "git", "apply", "-")
+            String execId = dockerClient.createComplexCommand(getContainerId(), "git", "apply", "-")
                     .withHereDocument(patch)
                     .withOutputStream(outputStream)
                     .withErrorStream(errorStream)

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/ContainerService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/ContainerService.java
@@ -77,6 +77,10 @@ public class ContainerService extends AbstractService {
         this.containerId = containerId;
     }
 
+    final protected String getContainerId() {
+        return containerId;
+    }
+
     final void setDockerClient(DockerClient dockerClient) {
         this.dockerClient = dockerClient;
     }

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/OntopService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/OntopService.java
@@ -110,7 +110,7 @@ public final class OntopService extends ContainerService {
     @Override
     public void doFirstTimePostStartUpConfiguration() {
         DockerClient dockerClient = DockerClient.getInstance();
-        String containerId = dockerClient.getContainerId(containerName);
+        String containerId = getContainerId();
         dockerClient.createComplexCommand(containerId, "chown", "ontop:ontop", String.join(" ", configDirs))
                 .withUser("root").exec();
 

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/OntopService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/OntopService.java
@@ -114,7 +114,7 @@ public final class OntopService extends ContainerService {
         dockerClient.createComplexCommand(containerId, "chown", "ontop:ontop", String.join(" ", configDirs))
                 .withUser("root").exec();
 
-        OntopClient ontopClient = OntopClient.getInstance();
+        OntopClient ontopClient = OntopClient.getInstance(containerName);
         configFiles.forEach(f -> {
             if (!fileExists(f)) {
                 String extension = FilenameUtils.getExtension(f);

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.43.0
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.43.1-fix-ontop-empty-file-creation-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.44.1-fix-ontop-empty-file-creation-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.44.1
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.43.0</version>
+    <version>1.43.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.43.0</version>
+            <version>1.43.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.44.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
+    <version>1.44.1</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.44.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
+            <version>1.44.1</version>
         </dependency>
 
         <dependency>

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.44.1-fix-ontop-empty-file-creation-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.44.1
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.43.0
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.43.1-fix-ontop-empty-file-creation-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.44.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
+    <version>1.44.1</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.44.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
+            <version>1.44.1</version>
         </dependency>
 
         <dependency>

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.43.0</version>
+    <version>1.43.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.43.0</version>
+            <version>1.43.1-fix-ontop-empty-file-creation-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Empty Ontop config files were not being created for the non-default containers. This has been fixed and the method responsible removed.