### PR TITLE
Hotfix Podman health check

### DIFF
--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.46.2
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.46.3-podman-health-check-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.46.3-podman-health-check-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.46.3
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.46.2</version>
+    <version>1.46.3-podman-health-check-SNAPSHOT</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.46.3-podman-health-check-SNAPSHOT</version>
+    <version>1.46.3</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/PodmanService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/PodmanService.java
@@ -309,7 +309,7 @@ public class PodmanService extends DockerService {
                 Schema2HealthConfig healthConfig = new Schema2HealthConfig()
                         .test(healthCheck.getTest())
                         .startPeriod(healthCheck.getStartPeriod().intValue())
-                        // TODO: Podman only supports "startInterval" from v5 which we can use yet.
+                        // TODO: Podman only supports "startInterval" from v5, which we can't use yet.
                         // .startInterval(healthCheck.getStartInterval().intValue())
                         .interval(healthCheck.getInterval().intValue())
                         .timeout(healthCheck.getTimeout().intValue())

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/PodmanService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/PodmanService.java
@@ -309,6 +309,8 @@ public class PodmanService extends DockerService {
                 Schema2HealthConfig healthConfig = new Schema2HealthConfig()
                         .test(healthCheck.getTest())
                         .startPeriod(healthCheck.getStartPeriod().intValue())
+                        // TODO: Podman only supports "startInterval" from v5 which we can use yet.
+                        // .startInterval(healthCheck.getStartInterval().intValue())
                         .interval(healthCheck.getInterval().intValue())
                         .timeout(healthCheck.getTimeout().intValue())
                         .retries(healthCheck.getRetries().longValue());

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/PodmanService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/PodmanService.java
@@ -33,6 +33,7 @@ import com.cmclinnovations.swagger.podman.model.Namespace;
 import com.cmclinnovations.swagger.podman.model.PerNetworkOptions;
 import com.cmclinnovations.swagger.podman.model.PodSpecGenerator;
 import com.cmclinnovations.swagger.podman.model.PortMapping;
+import com.cmclinnovations.swagger.podman.model.Schema2HealthConfig;
 import com.cmclinnovations.swagger.podman.model.Secret;
 import com.cmclinnovations.swagger.podman.model.SecretInfoReport;
 import com.cmclinnovations.swagger.podman.model.SpecGenerator;
@@ -42,6 +43,7 @@ import com.github.dockerjava.api.model.ContainerSpecConfig;
 import com.github.dockerjava.api.model.ContainerSpecFile;
 import com.github.dockerjava.api.model.ContainerSpecSecret;
 import com.github.dockerjava.api.model.EndpointSpec;
+import com.github.dockerjava.api.model.HealthCheck;
 import com.github.dockerjava.api.model.MountType;
 import com.github.dockerjava.api.model.NetworkAttachmentConfig;
 import com.github.dockerjava.api.model.PortConfig;
@@ -296,9 +298,23 @@ public class PodmanService extends DockerService {
             }
             containerSpecGenerator.setLabels(containerSpec.getLabels());
 
+            // Copy across the restart policy
             ServiceRestartPolicy restartPolicy = serviceSpec.getTaskTemplate().getRestartPolicy();
             containerSpecGenerator.setRestartPolicy(restartPolicyMap.get(restartPolicy.getCondition()));
             containerSpecGenerator.setRestartTries((Integer) restartPolicy.getMaxAttempts().intValue());
+
+            // Copy across any user specified health check
+            HealthCheck healthCheck = containerSpec.getHealthCheck();
+            if (healthCheck != null) {
+                Schema2HealthConfig healthConfig = new Schema2HealthConfig()
+                        .test(healthCheck.getTest())
+                        .startPeriod(healthCheck.getStartPeriod().intValue())
+                        .interval(healthCheck.getInterval().intValue())
+                        .timeout(healthCheck.getTimeout().intValue())
+                        .retries(healthCheck.getRetries().longValue());
+
+                containerSpecGenerator.setHealthconfig(healthConfig);
+            }
 
             try {
                 ContainersApi containersApi = new ContainersApi(getClient().getPodmanClient());

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.46.3-podman-health-check-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.46.3
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.46.2
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.46.3-podman-health-check-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.46.2</version>
+    <version>1.46.3-podman-health-check-SNAPSHOT</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.46.2</version>
+            <version>1.46.3-podman-health-check-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.46.3-podman-health-check-SNAPSHOT</version>
+    <version>1.46.3</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.46.3-podman-health-check-SNAPSHOT</version>
+            <version>1.46.3</version>
         </dependency>
 
         <dependency>

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.46.3-podman-health-check-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.46.3
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.46.2
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.46.3-podman-health-check-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.46.3-podman-health-check-SNAPSHOT</version>
+    <version>1.46.3</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.46.3-podman-health-check-SNAPSHOT</version>
+            <version>1.46.3</version>
         </dependency>
 
         <dependency>

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.46.2</version>
+    <version>1.46.3-podman-health-check-SNAPSHOT</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.46.2</version>
+            <version>1.46.3-podman-health-check-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixed issues with the stack manager not waiting for containers to have started up before continuing. This includes ensuring that health checks defined in the .json files are used.