### PR TITLE
Extended the documentation regarding the outgoing federation repository

### DIFF
--- a/stack-manager/README.md
+++ b/stack-manager/README.md
@@ -290,15 +290,15 @@ The format of the stack configuration file is as follows:
 
 An RDF4J server is added to each stack and allows for SPARQL federation across all sparql endpoints within a TWA Stack as well as external endpoints and other TWA Stacks.
 
-## Repositories
+### Repositories
 
-### Dataset repository
+#### Dataset repository
 
 A dataset repository is one that federates across each endpoint related to a dataset in a stack.
 When a new dataset is added to this stack a new federated dataset repository will be added.
 This repository will persist for long as the dataset does.
 
-### Incoming stack repository
+#### Incoming stack repository
 
 An incoming stack repository federates across each [dataset repository](#dataset-repository) in a stack.
 This repository will be used by external clients querying data in this stack.
@@ -307,7 +307,7 @@ This repository will persist for as long as stack does but changes as datasets a
 
 This repository can be accessed at external to the stack at `http://localhost:<PORT>/rdf4j-server/repositories/stack-incoming/`.
 
-### Outgoing stack endpoint
+#### Outgoing stack endpoint
 
 An outgoing stack endpoint is a federation between internal and external endpoints.
 This endpoint will be used by agents internal to this stack, accessing internal and external data.
@@ -316,7 +316,7 @@ This repository will persist for as long as stack does but changes if external e
 
 This repository can be accessed at internal to the stack at `http://<STACK NAME>-rdf4j:8080/rdf4j-server/repositories/stack-outgoing/`.
 
-## Design
+### Design
 
 The diagram below illustrates how each of the federated repositories are related to each other.
 

--- a/stack-manager/README.md
+++ b/stack-manager/README.md
@@ -305,16 +305,16 @@ This repository will be used by external clients querying data in this stack.
 When a new dataset is added to this stack its dataset repository will be added to this federation.
 This repository will persist for as long as stack does but changes as datasets are added and removed.
 
-This repository can be accessed at external to the stack at `http://localhost:<PORT>/rdf4j-server/repositories/stack-incoming/`.
+This repository can be accessed from outside the stack at `http://localhost:<PORT>/sparql/query`.
 
 #### Outgoing stack endpoint
 
 An outgoing stack endpoint is a federation between internal and external endpoints.
-This endpoint will be used by agents internal to this stack, accessing internal and external data.
-It is not used by external clients in case loops are caused with other stacks.
-This repository will persist for as long as stack does but changes if external endpoints are added and removed.
+This endpoint should be used by agents internal to this stack when accessing internal and external data.
+It should not be used by external clients in case loops are created between stacks.
+This repository will persist for as long as the stack does but will change if any external endpoints are added or removed.
 
-This repository can be accessed at internal to the stack at `http://<STACK NAME>-rdf4j:8080/rdf4j-server/repositories/stack-outgoing/`.
+This repository can be accessed from inside the stack at `http://<STACK NAME>-rdf4j:8080/rdf4j-server/repositories/stack-outgoing/`.
 
 ### Design
 

--- a/stack-manager/README.md
+++ b/stack-manager/README.md
@@ -316,6 +316,29 @@ This repository will persist for as long as the stack does but will change if an
 
 This repository can be accessed from inside the stack at `http://<STACK NAME>-rdf4j:8080/rdf4j-server/repositories/stack-outgoing/`.
 
+External endpoints can be registered in a stack by specifying an ID, display name, and the URL of the endpoint in a JSON file in the directory `stack-manager/inputs/config/external_endpoints/`.
+As mentioned above, when referencing another stack it is recommended to point to its incoming endpoint as pointing to its outgoing one might cause a loop.
+
+For example to include a stack called "test2" in the outgoing federation you would add this file:
+
+```json
+{
+    "id": "test2",
+    "name": "Second test stack",
+    "url": "https://test2.theworldavatar.io/sparql/query"
+}
+```
+
+To include the OpenStreetMap SPARQL endpoint in the outgoing federation you could add a file like this one:
+
+```json
+{
+    "id": "openstreetmap-qlever",
+    "name": "OSM QLever",
+    "url": "https://qlever.cs.uni-freiburg.de/api/osm-planet"
+}
+```
+
 ### Design
 
 The diagram below illustrates how each of the federated repositories are related to each other.


### PR DESCRIPTION
Updated the documentation regarding the federated endpoints, mainly by adding examples of how to specify external repositories.