### PR TITLE
Fix Docker compose convert issue

### DIFF
--- a/common-scripts/build.sh
+++ b/common-scripts/build.sh
@@ -18,7 +18,7 @@ if [[ -f "docker-compose-build-test.yml" ]]; then
     # Build the test image
     ${COMPOSE_EXECUTABLE} -f docker-compose-stack.yml -f docker-compose.yml -f docker-compose-build.yml -f docker-compose-build-test.yml build --build-arg CACHEBUST="${CACHEBUST}" "$@"
     # Get the image names and iterate over them
-    for test_image in $(${COMPOSE_EXECUTABLE} -f docker-compose-stack.yml -f docker-compose.yml -f docker-compose-build.yml -f docker-compose-build-test.yml convert --images); do
+    for test_image in $(${COMPOSE_EXECUTABLE} -f docker-compose-stack.yml -f docker-compose.yml -f docker-compose-build.yml -f docker-compose-build-test.yml config --images); do
         # Run the test image
         ${EXECUTABLE} run --rm --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock "$test_image"
         # Remove the test image

--- a/common-scripts/stop.sh
+++ b/common-scripts/stop.sh
@@ -8,7 +8,7 @@ export EXTERNAL_PORT="EXTERNAL_PORT should only be required at runtime!"
 
 # Remove existing services started from this directory
 if [ "$EXECUTABLE" == "docker" ]; then
-    for SERVICE in $(${COMPOSE_EXECUTABLE} -f docker-compose-stack.yml -f docker-compose.yml convert --services); do
+    for SERVICE in $(${COMPOSE_EXECUTABLE} -f docker-compose-stack.yml -f docker-compose.yml config --services); do
         if [ -n "$(${EXECUTABLE} service ls -q -f "name=${STACK_NAME}_${SERVICE}")" ]; then
             ${EXECUTABLE} service rm "${STACK_NAME}_${SERVICE}" > /dev/null
         fi


### PR DESCRIPTION
Docker have removed the `convert` alias for the `docker compose config` command. The relevant scripts have been updated.