### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/clients/docker/DockerClient.java
@@ -493,7 +493,11 @@ public class DockerClient extends BaseClient implements ContainerManager<com.git
             TarArchiveEntry tarArchiveEntry;
             while (null != (tarArchiveEntry = tarArchiveInputStream.getNextTarEntry())) {
                 if (!tarArchiveEntry.isDirectory()) {
-                    files.put(remoteDirPath + tarArchiveEntry.getName().replaceFirst("^[^/]*/", ""),
+                    Path entryPath = Path.of(remoteDirPath, tarArchiveEntry.getName().replaceFirst("^[^/]*/", "")).normalize();
+                    if (!entryPath.startsWith(Path.of(remoteDirPath).normalize())) {
+                        throw new IOException("Invalid tar entry: " + tarArchiveEntry.getName());
+                    }
+                    files.put(entryPath.toString(),
                             tarArchiveInputStream.readAllBytes());
                 }
             }


### PR DESCRIPTION
Potential fix for [https://github.com/TheWorldAvatar/stack/security/code-scanning/1](https://github.com/TheWorldAvatar/stack/security/code-scanning/1)

To fix the issue, the code must validate the paths extracted from the tar archive to ensure they do not lead to directory traversal. This can be achieved by normalizing the paths and verifying that they remain within the intended target directory. Specifically:
1. Use `Path.normalize()` or `File.getCanonicalFile()` to normalize the paths.
2. Check that the normalized path starts with the intended base directory (`targetDir`).
3. Reject or skip entries that fail this validation.

The fix will involve modifying the `retrieveFiles` method to validate `tarArchiveEntry.getName()` before adding it to the `files` map. Additionally, the `copyTo` method will indirectly benefit from this validation since it uses the output of `retrieveFiles`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
