### PR TITLE
Add dependency management to ensure consistent Jersey versions for Podman API dynamically generated by Swagger

### DIFF
--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.58.0
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.58.1-dev-swagger-dependencies-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.58.1-dev-swagger-dependencies-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.58.1
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -47,6 +47,19 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <!-- Ensure consistent versions of Jersey dependencies generated dynamically by Swagger for Podman API -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>2.41</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.58.1-dev-swagger-dependencies-SNAPSHOT</version>
+    <version>1.58.1</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.58.0</version>
+    <version>1.58.1-dev-swagger-dependencies-SNAPSHOT</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.58.0
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.58.1-dev-swagger-dependencies-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.58.1-dev-swagger-dependencies-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.58.1
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.58.1-dev-swagger-dependencies-SNAPSHOT</version>
+    <version>1.58.1</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.58.0</version>
+    <version>1.58.1-dev-swagger-dependencies-SNAPSHOT</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.58.1-dev-swagger-dependencies-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.58.1
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.58.0
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.58.1-dev-swagger-dependencies-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.58.0</version>
+    <version>1.58.1-dev-swagger-dependencies-SNAPSHOT</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.58.1-dev-swagger-dependencies-SNAPSHOT</version>
+    <version>1.58.1</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>


### PR DESCRIPTION
This resolves issue #87.