### PR TITLE
Fix rerunning stack manager fails

### DIFF
--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.60.0
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.60.1
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.60.0</version>
+    <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
+    <version>1.60.1</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/DockerService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/DockerService.java
@@ -159,7 +159,12 @@ public class DockerService extends AbstractService
                 }
             });
             for (Config oldConfig : existingStackConfigs) {
-                dockerClient.removeConfig(oldConfig);
+                try {
+                    dockerClient.removeConfig(oldConfig);
+                } catch (BadRequestException ex) {
+                    // This probably just means that the config was generated rather then loaded
+                    // from file.
+                }
             }
         } catch (IOException ex) {
             throw new RuntimeException("Failed to load configs.", ex);

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/services/DockerService.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/services/DockerService.java
@@ -33,6 +33,7 @@ import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.command.RemoveServiceCmd;
+import com.github.dockerjava.api.exception.BadRequestException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Config;
 import com.github.dockerjava.api.model.Container;
@@ -187,7 +188,12 @@ public class DockerService extends AbstractService
         }
 
         for (Secret oldSecret : existingStackSecrets) {
-            dockerClient.removeSecret(oldSecret);
+            try {
+                dockerClient.removeSecret(oldSecret);
+            } catch (BadRequestException ex) {
+                // This probably just means that the secret was generated rather then loaded
+                // from file.
+            }
         }
     }
 

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.60.1
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.60.0
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.60.0</version>
+    <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.60.0</version>
+            <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
+    <version>1.60.1</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
+            <version>1.60.1</version>
         </dependency>
 
         <dependency>

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.60.1
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.60.0
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.60.0</version>
+    <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.60.0</version>
+            <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
+    <version>1.60.1</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.60.1-fix-rerunning-stack-manager-fails-SNAPSHOT</version>
+            <version>1.60.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Default secrets that were not uploaded from file were causing an exception to be thrown when the stack manager incorrectly tried to remove them.

Closes #91