### PR TITLE
Match other stack services' endpoint resolution

### DIFF
--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.60.1
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.60.2-endpoint-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/docker-compose.yml
+++ b/stack-clients/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-client:
-    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.60.2-endpoint-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-client${IMAGE_SUFFIX}:1.60.2
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.60.2-endpoint-SNAPSHOT</version>
+    <version>1.60.2</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/pom.xml
+++ b/stack-clients/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-clients</artifactId>
-    <version>1.60.1</version>
+    <version>1.60.2-endpoint-SNAPSHOT</version>
 
     <name>Stack Clients</name>
     <url>https://theworldavatar.io</url>

--- a/stack-clients/src/main/java/com/cmclinnovations/stack/clients/rdf4j/Rdf4jEndpointConfig.java
+++ b/stack-clients/src/main/java/com/cmclinnovations/stack/clients/rdf4j/Rdf4jEndpointConfig.java
@@ -22,7 +22,7 @@ public class Rdf4jEndpointConfig extends PasswordEndpointConfig {
         this.hostName = hostName;
         this.port = port;
         this.username = username;
-        this.serviceUrl = "http://" + this.hostName + ":" + this.port;
+        this.serviceUrl = null;
     }
 
     public String getHostName() {
@@ -38,7 +38,10 @@ public class Rdf4jEndpointConfig extends PasswordEndpointConfig {
     }
 
     public String getServiceUrl() {
-        return serviceUrl;
+        if (null != serviceUrl && !serviceUrl.isBlank()) {
+            return serviceUrl;
+        }
+        return "http://" + hostName + ":" + port;
     }
 
     @JsonIgnore

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.60.1
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.60.2-endpoint-SNAPSHOT
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/docker-compose.yml
+++ b/stack-data-uploader/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-data-uploader:
-    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.60.2-endpoint-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-data-uploader${IMAGE_SUFFIX}:1.60.2
     secrets:
       - blazegraph_password
       - postgis_password

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.60.1</version>
+    <version>1.60.2-endpoint-SNAPSHOT</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.60.1</version>
+            <version>1.60.2-endpoint-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/stack-data-uploader/pom.xml
+++ b/stack-data-uploader/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-data-uploader</artifactId>
-    <version>1.60.2-endpoint-SNAPSHOT</version>
+    <version>1.60.2</version>
 
     <name>Stack Data Uploader</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.60.2-endpoint-SNAPSHOT</version>
+            <version>1.60.2</version>
         </dependency>
 
         <dependency>

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.60.1
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.60.2-endpoint-SNAPSHOT
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/docker-compose.yml
+++ b/stack-manager/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   stack-manager:
-    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.60.2-endpoint-SNAPSHOT
+    image: ghcr.io/theworldavatar/stack-manager${IMAGE_SUFFIX}:1.60.2
     environment:
       EXTERNAL_PORT: "${EXTERNAL_PORT-3838}"
       STACK_BASE_DIR: "${STACK_BASE_DIR}"

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.60.2-endpoint-SNAPSHOT</version>
+    <version>1.60.2</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.60.2-endpoint-SNAPSHOT</version>
+            <version>1.60.2</version>
         </dependency>
 
         <dependency>

--- a/stack-manager/pom.xml
+++ b/stack-manager/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.cmclinnovations</groupId>
     <artifactId>stack-manager</artifactId>
-    <version>1.60.1</version>
+    <version>1.60.2-endpoint-SNAPSHOT</version>
 
     <name>Stack Manager</name>
     <url>https://theworldavatar.io</url>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.cmclinnovations</groupId>
             <artifactId>stack-clients</artifactId>
-            <version>1.60.1</version>
+            <version>1.60.2-endpoint-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
so we don't need the clunky extra field in the endpoint config map like this:

```  rdf4j: |
    {
      "name": "rdf4j",
      "hostName": "rdf4j",
      "port": "8080",
      "serviceUrl": "http://rdf4j:8080",
      "username": {{ .Values.rdf4j.username | quote }},
      "passwordFile": "/run/secrets/rdf4j_password"
    }
```

see how it's done in 

`com.cmclinnovations.stack.clients.blazegraph.BlazegraphEndpointConfig.getServiceUrl()`